### PR TITLE
Use new syntax to set output, set-command is deprecated

### DIFF
--- a/.github/workflows/nexus.yaml
+++ b/.github/workflows/nexus.yaml
@@ -28,7 +28,7 @@ jobs:
         run: |
           set -o pipefail
           PKG=$(make package | tail -n1 | awk -F '/' '{printf $NF}')
-          echo ::set-output name=helm_package_name::$PKG
+          echo "helm_package_name=${PKG}" >> $GITHUB_OUTPUT
 
       - name: Push to Nexus
         env:

--- a/.github/workflows/sync-manifests.yaml
+++ b/.github/workflows/sync-manifests.yaml
@@ -85,7 +85,7 @@ jobs:
           cp -r service/${{ inputs.manifests_dir }} .manifests
           make docker-login sync-manifests
           actions_user_id=`id -u $USER`
-          echo ::set-output name=uid::$actions_user_id
+          echo "uid=${actions_user_id}" >> $GITHUB_OUTPUT
           sudo rm -rf .manifests
           sudo rm -rf service
 


### PR DESCRIPTION
The deprecations warnings in annotations are annoying:

![image](https://user-images.githubusercontent.com/570991/196729022-f3563efc-2c6c-467f-8ed1-193f2e693fdd.png)

