### PR TITLE
DX2-000 - simplify validate manifests workflow

### DIFF
--- a/.github/workflows/validate-manifests.yaml
+++ b/.github/workflows/validate-manifests.yaml
@@ -41,8 +41,20 @@ on:
 env:
   DOCKER_REGISTRY_USER: ${{ secrets.docker_user }}
   DOCKER_REGISTRY_PASSWORD: ${{ secrets.docker_pass }}
+  YQ_RELEASE_URL: https://github.com/mikefarah/yq/releases/download/v4.25.2/yq_linux_amd64
 
 jobs:
+  matrix:
+    runs-on: self-hosted
+    steps:
+      - name: JSON stringify - environments
+        id: parse-environments
+        run: >-
+          echo "environments=[\"${environments//','/\",\"}\"]" >> $GITHUB_OUTPUT
+        env:
+          environments: ${{ inputs.environments }}
+    outputs:
+      environments: ${{ steps.parse-environments.outputs.environments }}
   sync-manifests:
     runs-on: self-hosted
     steps:
@@ -113,11 +125,14 @@ jobs:
         if: steps.retrieve-manifests.outputs.cache-hit == 'true'
         run: make docker-login validate-manifests
 
-  validate-schemas-beta:
-    needs: sync-manifests
+  validate-schemas:
+    needs: [matrix, sync-manifests]
+    strategy:
+      matrix:
+        env: ${{fromJSON(needs.matrix.outputs.environments)}}
     runs-on:
       - self-hosted
-      - stuart-beta
+      - stuart-${{ matrix.env }}
     steps:
       - name: Retrieve k8s-manifests
         id: retrieve-manifests
@@ -130,195 +145,20 @@ jobs:
       - name: Kubectl dry-run
         working-directory: .
         run: |
-          sudo wget -q https://github.com/mikefarah/yq/releases/download/v4.25.2/yq_linux_amd64 -O /usr/bin/yq
+          sudo wget -q "$YQ_RELEASE_URL" -O /usr/bin/yq
           sudo chmod +x /usr/bin/yq
-          if [ -d .changed_manifests/beta ]; then
-            echo "Manifests for beta were found, running validation"
-            ls -R .changed_manifests/
-            for FILE in $(find .changed_manifests -name '*.yaml'); do
-              yq -i '.metadata.namespace = "dry-run-ns"' "$FILE"
-            done
-            kubectl apply --validate=true --dry-run=server -R -f .changed_manifests/beta/
-          else
-            echo "Manifests for beta not found, skipping validation"
+
+          if [ ! -d ".changed_manifests/${{ matrix.env }}" ]; then
+            echo "Manifests for ${{ matrix.env }} not found, skipping validation"
+            exit 0
           fi
 
-  validate-schemas-dev:
-    needs: sync-manifests
-    runs-on:
-      - self-hosted
-      - stuart-dev
-    steps:
-      - name: Retrieve k8s-manifests
-        id: retrieve-manifests
-        uses: actions/cache@v3
-        with:
-          path: .
-          key: manifests-${{ github.run_id }}-${{ github.run_number }}
-      - name: install kubeclt
-        uses: azure/setup-kubectl@v2.0
-      - name: Kubectl dry-run
-        working-directory: .
-        run: |
-          sudo wget -q https://github.com/mikefarah/yq/releases/download/v4.25.2/yq_linux_amd64 -O /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
-          if [ -d .changed_manifests/dev ]; then
-            echo "Manifests for dev were found, running validation"
-            ls -R .changed_manifests/
-            for FILE in $(find .changed_manifests -name '*.yaml'); do
-              yq -i '.metadata.namespace = "dry-run-ns"' "$FILE"
-            done
-            kubectl apply --validate=true --dry-run=server -R -f .changed_manifests/dev/
-          else
-            echo "Manifests for dev not found, skipping validation"
-          fi
+          echo "Manifests for ${{ matrix.env }} were found, running validation"
+          ls -R .changed_manifests/
 
-  validate-schemas-dispload:
-    needs: sync-manifests
-    runs-on:
-      - self-hosted
-      - stuart-dispload
-    steps:
-      - name: Retrieve k8s-manifests
-        id: retrieve-manifests
-        uses: actions/cache@v3
-        with:
-          path: .
-          key: manifests-${{ github.run_id }}-${{ github.run_number }}
-      - name: install kubeclt
-        uses: azure/setup-kubectl@v2.0
-      - name: Kubectl dry-run
-        working-directory: .
-        run: |
-          sudo wget -q https://github.com/mikefarah/yq/releases/download/v4.25.2/yq_linux_amd64 -O /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
-          if [ -d .changed_manifests/dispload ]; then
-            echo "Manifests for dispload were found, running validation"
-            ls -R .changed_manifests/
-            for FILE in $(find .changed_manifests -name '*.yaml'); do
-              yq -i '.metadata.namespace = "dry-run-ns"' "$FILE"
-            done
-            kubectl apply --validate=true --dry-run=server -R -f .changed_manifests/dispload/
-          else
-            echo "Manifests for dispload not found, skipping validation"
-          fi
+          for FILE in $(find .changed_manifests -name '*.yaml'); do
+            yq -i '.metadata.namespace = "dry-run-ns"' "$FILE"
+          done
 
-  validate-schemas-mgmt:
-    needs: sync-manifests
-    runs-on:
-      - self-hosted
-      - stuart-mgmt
-    steps:
-      - name: Retrieve k8s-manifests
-        id: retrieve-manifests
-        uses: actions/cache@v3
-        with:
-          path: .
-          key: manifests-${{ github.run_id }}-${{ github.run_number }}
-      - name: install kubeclt
-        uses: azure/setup-kubectl@v2.0
-      - name: Kubectl dry-run
-        working-directory: .
-        run: |
-          sudo wget -q https://github.com/mikefarah/yq/releases/download/v4.25.2/yq_linux_amd64 -O /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
-          if [ -d .changed_manifests/mgmt ]; then
-            echo "Manifests for mgmt were found, running validation"
-            ls -R .changed_manifests/
-            for FILE in $(find .changed_manifests -name '*.yaml'); do
-              yq -i '.metadata.namespace = "dry-run-ns"' "$FILE"
-            done
-            kubectl apply --validate=true --dry-run=server -R -f .changed_manifests/mgmt/
-          else
-            echo "Manifests for mgmt not found, skipping validation"
-          fi
-
-  validate-schemas-prod:
-    needs: sync-manifests
-    runs-on:
-      - self-hosted
-      - stuart-prod
-    steps:
-      - name: Retrieve k8s-manifests
-        id: retrieve-manifests
-        uses: actions/cache@v3
-        with:
-          path: .
-          key: manifests-${{ github.run_id }}-${{ github.run_number }}
-      - name: install kubeclt
-        uses: azure/setup-kubectl@v2.0
-      - name: Kubectl dry-run
-        working-directory: .
-        run: |
-          sudo wget -q https://github.com/mikefarah/yq/releases/download/v4.25.2/yq_linux_amd64 -O /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
-          if [ -d .changed_manifests/prod ]; then
-            echo "Manifests for prod were found, running validation"
-            ls -R .changed_manifests/
-            for FILE in $(find .changed_manifests -name '*.yaml'); do
-              yq -i '.metadata.namespace = "dry-run-ns"' "$FILE"
-            done
-            kubectl apply --validate=true --dry-run=server -R -f .changed_manifests/prod/
-          else
-            echo "Manifests for prod not found, skipping validation"
-          fi
-
-  validate-schemas-qa:
-    needs: sync-manifests
-    runs-on:
-      - self-hosted
-      - stuart-qa
-    steps:
-      - name: Retrieve k8s-manifests
-        id: retrieve-manifests
-        uses: actions/cache@v3
-        with:
-          path: .
-          key: manifests-${{ github.run_id }}-${{ github.run_number }}
-      - name: install kubeclt
-        uses: azure/setup-kubectl@v2.0
-      - name: Kubectl dry-run
-        working-directory: .
-        run: |
-          sudo wget -q https://github.com/mikefarah/yq/releases/download/v4.25.2/yq_linux_amd64 -O /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
-          if [ -d .changed_manifests/qa ]; then
-            echo "Manifests for qa were found, running validation"
-            ls -R .changed_manifests/
-            for FILE in $(find .changed_manifests -name '*.yaml'); do
-              yq -i '.metadata.namespace = "dry-run-ns"' "$FILE"
-            done
-            kubectl apply --validate=true --dry-run=server -R -f .changed_manifests/qa/
-          else
-            echo "Manifests for qa not found, skipping validation"
-          fi
-
-  validate-schemas-sandbox:
-    needs: sync-manifests
-    runs-on:
-      - self-hosted
-      - stuart-sandbox
-    steps:
-      - name: Retrieve k8s-manifests
-        id: retrieve-manifests
-        uses: actions/cache@v3
-        with:
-          path: .
-          key: manifests-${{ github.run_id }}-${{ github.run_number }}
-      - name: install kubeclt
-        uses: azure/setup-kubectl@v2.0
-      - name: Kubectl dry-run
-        working-directory: .
-        run: |
-          sudo wget -q https://github.com/mikefarah/yq/releases/download/v4.25.2/yq_linux_amd64 -O /usr/bin/yq
-          sudo chmod +x /usr/bin/yq
-          if [ -d .changed_manifests/sandbox ]; then
-            echo "Manifests for sandbox were found, running validation"
-            ls -R .changed_manifests/
-            for FILE in $(find .changed_manifests -name '*.yaml'); do
-              yq -i '.metadata.namespace = "dry-run-ns"' "$FILE"
-            done
-            kubectl apply --validate=true --dry-run=server -R -f .changed_manifests/sandbox/
-          else
-            echo "Manifests for sandbox not found, skipping validation"
-          fi
+          kubectl apply --validate=true --dry-run=server --server-side \
+            --force-conflicts -R -f ".changed_manifests/${{ matrix.env }}/"


### PR DESCRIPTION
The following PR simplifies the `validate-manifests` workflow by:

- Big :scissors: around `validate-schemas` duplicity
- Execute `validate-schemas` **only** against the workflow callee environments supplied through `inputs.environments` by building a GHAW matrix from it.
- Refactor `validate-schemas::kubectl dry-run` step:
   - Replace **if/else** and use **guard clause** instead.
   - Pull up **YQ_RELEASE_URL** as workflow env.
- Use **SSA - server side apply**, mainly because otherwise we can't validate/dry-run objects exceeding 256Kb of the underlying [last-applied-configuration](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#how-to-create-objects) annotation (mostly CRD's as part of our CI pipeline).
- Add `--force-conflicts`, tightly coupled with SSA and [field ownership management](https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts) (not a problem - at the end is a dry-run).

### How it looks like:
Given a GHAW callee such as the following:
```
jobs:
  validate-manifests:
    uses: stuartapp/dx2-gh-actions/.github/workflows/validate-manifests.yaml@main
    with:
      git_repo: ${{ github.repository }}
      git_pr_branch: ${{ github.ref }}
      environments: mgmt,dev,beta
      service_config_files: xxx.yaml
      manifests_dir: xxxx/yyyy
    secrets:
      gh_token: ${{ secrets.GHA_TRIGGER_TOKEN }}
      docker_user: ${{ secrets.DOCKER_REGISTRY_USER }}
      docker_pass: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
```
Produces:

![image](https://user-images.githubusercontent.com/10697727/207914954-239ef8ab-9586-461e-803c-82af2f6d3bb8.png)
